### PR TITLE
Remove libc dependency and bump the version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,12 @@
 [package]
 name          = "khronos"
-version       = "0.1.2"
+version       = "0.2.0"
 authors       = ["Sean Kerr <sean@metatomic.io>"]
 license       = "Apache-2.0"
 description   = "Rust types for Khronos API"
 homepage      = "https://github.com/seankerr/rust-khronos"
 repository    = "https://github.com/seankerr/rust-khronos"
+edition       = "2018"
 readme        = "README.md"
 keywords      = ["egl", "gl", "khronos", "opengl"]
 exclude       = [".gitignore"]
-
-[dependencies]
-libc = "0.1.10"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,39 +16,26 @@
 // | Author: Sean Kerr <sean@metatomic.io>                                                         |
 // +-----------------------------------------------------------------------------------------------+
 
-#![crate_name = "khronos"]
 #![allow(non_camel_case_types)]
-
-extern crate libc;
-
-use libc::{ c_float,
-            int8_t,
-            int16_t,
-            int32_t,
-            int64_t,
-            uint8_t,
-            uint16_t,
-            uint32_t,
-            uint64_t };
 
 // -------------------------------------------------------------------------------------------------
 // TYPES
 // -------------------------------------------------------------------------------------------------
 
-pub type khronos_float_t  = c_float;
-pub type khronos_int8_t   = int8_t;
-pub type khronos_uint8_t  = uint8_t;
-pub type khronos_int16_t  = int16_t;
-pub type khronos_uint16_t = uint16_t;
-pub type khronos_int32_t  = int32_t;
-pub type khronos_uint32_t = uint32_t;
-pub type khronos_int64_t  = int64_t;
-pub type khronos_uint64_t = uint64_t;
+pub type khronos_float_t = f32;
+pub type khronos_int8_t = i8;
+pub type khronos_uint8_t = u8;
+pub type khronos_int16_t = i16;
+pub type khronos_uint16_t = u16;
+pub type khronos_int32_t = i32;
+pub type khronos_uint32_t = u32;
+pub type khronos_int64_t = i64;
+pub type khronos_uint64_t = u64;
 
-pub type khronos_intptr_t  = int32_t;
-pub type khronos_uintptr_t = uint32_t;
-pub type khronos_ssize_t   = int32_t;
-pub type khronos_usize_t   = uint32_t;
+pub type khronos_intptr_t = i32;
+pub type khronos_uintptr_t = u32;
+pub type khronos_ssize_t = i32;
+pub type khronos_usize_t = u32;
 
-pub type khronos_stime_nanoseconds_t = khronos_int64_t;
-pub type khronos_utime_nanoseconds_t = khronos_uint64_t;
+pub type khronos_stime_nanoseconds_t = i64;
+pub type khronos_utime_nanoseconds_t = u64;


### PR DESCRIPTION
The ecosystem migrated to libc-0.2 a while ago. If I just change the dependency version, I get a lot of warnings like:
> warning: use of deprecated type alias `libc::int64_t`: Use i64 instead.

So I did that, and removed `libc` as a dependency altogether.
Now I wonder, does this crate need to exist at all? It's just a couple of typedefs.

More practical, we'd like this to be resolved before we can fully accomplish https://github.com/gfx-rs/wgpu/issues/1027